### PR TITLE
Handle case where ancestor of target is missing

### DIFF
--- a/lib/hana.rb
+++ b/lib/hana.rb
@@ -18,6 +18,8 @@ module Hana
 
     def self.eval list, object
       list.inject(object) { |o, part|
+        return nil unless o
+
         if Array === o
           raise Patch::IndexError unless part =~ /\A\d+\Z/
           part = part.to_i

--- a/test/test_hana.rb
+++ b/test/test_hana.rb
@@ -56,4 +56,12 @@ class TestHana < Hana::TestCase
     pointer = Hana::Pointer.new '/foo/1'
     assert_equal 'baz', pointer.eval('foo' => { '1' => 'baz' })
   end
+
+  def test_eval_many_below_missing
+    pointer = Hana::Pointer.new '/baz/foo/bar'
+    assert_nil pointer.eval('foo' => 'bar')
+
+    pointer = Hana::Pointer.new '/foo/bar/baz'
+    assert_nil pointer.eval('foo' => nil)
+  end
 end


### PR DESCRIPTION
Currently if an ancestor of a patch target is missing `NoMethodError` is raised rather than `MissingTargetException`.
