### PR TITLE
Replace synopsis section with working code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ process it, then emit as JSON again.
 
 ```ruby
 patch = Hana::Patch.new [
-  { 'add' => '/baz', 'value' => 'qux' }
+  { 'op' => 'add', 'path' => '/baz', 'value' => 'qux' }
 ]
 
 patch.apply('foo' => 'bar') # => {'baz' => 'qux', 'foo' => 'bar'}


### PR DESCRIPTION
Hello Sir,

The Synopis section in the README doesn't seem to work in latest version (1.3.1).
```ruby
patch = Hana::Patch.new [
  { 'add' => '/baz', 'value' => 'qux' }
]
patch.apply('foo' => 'bar') # raises =>
# NoMethodError: undefined method `strip' for nil:NilClass
# from .../hana-1.3.1/lib/hana.rb:74:in `block in apply'
```

The attached patch provides the expected result, but it certainly is more verbose.
```ruby
patch = Hana::Patch.new [
  {'op' => 'add', 'path' => '/baz', 'value' => 'qux' }
]
patch.apply('foo' => 'bar') # => {"foo"=>"bar", "baz"=>"qux"}
```
Was the documented syntax meant to work as a shorthand? 

Cheers