### PR TITLE
Trailing slash support as per http://tools.ietf.org/html/rfc6901#section-5

### DIFF
--- a/lib/hana.rb
+++ b/lib/hana.rb
@@ -31,9 +31,13 @@ module Hana
     def self.parse path
       return [''] if path == '/'
 
-      path.sub(/^\//, '').split(/(?<!\^)\//).each { |part|
-        part.gsub!(/\^[\/^]|~[01]/) { |m| ESC[m] }
-      }
+      parts =
+        path.sub(/^\//, '').split(/(?<!\^)\//).each { |part|
+          part.gsub!(/\^[\/^]|~[01]/) { |m| ESC[m] }
+        }
+
+      parts.push("") if path[-1] == '/'
+      parts
     end
   end
 

--- a/test/test_hana.rb
+++ b/test/test_hana.rb
@@ -23,6 +23,11 @@ class TestHana < Hana::TestCase
     assert_equal %w{ foo bar baz }, pointer.to_a
   end
 
+  def test_split_with_trailing
+    pointer = Hana::Pointer.new '/foo/'
+    assert_equal ["foo", ""], pointer.to_a
+  end
+
   def test_root
     pointer = Hana::Pointer.new '/'
     assert_equal [''], pointer.to_a


### PR DESCRIPTION
A path terminating in a "/" means the final path segment is an empty string:

"/foo/bar" -> ['foo', 'bar']
"/foo/bar/" -> ['foo', 'bar', '']

Just using String#split results in losing the trailing slash.