### PR TITLE
Raise Patch::MissingTargetException when trying to replace a key inside a missing parent

### DIFF
--- a/lib/hana.rb
+++ b/lib/hana.rb
@@ -157,6 +157,7 @@ module Hana
         raise Patch::IndexError unless key =~ /\A\d+\Z/
         obj[key.to_i] = ins.fetch VALUE
       else
+        raise Patch::MissingTargetException unless obj
         obj[key] = ins.fetch VALUE
       end
       doc

--- a/test/test_hana.rb
+++ b/test/test_hana.rb
@@ -69,4 +69,43 @@ class TestHana < Hana::TestCase
     pointer = Hana::Pointer.new '/foo/bar/baz'
     assert_nil pointer.eval('foo' => nil)
   end
+
+  def test_remove_missing_object_key
+    patch = Hana::Patch.new [
+      { 'op' => 'remove', 'path' => '/missing_key' }
+    ]
+    assert_raises(Hana::Patch::IndexError) do
+      patch.apply('foo' => 'bar')
+    end
+  end
+
+  def test_remove_missing_array_index
+    patch = Hana::Patch.new [
+      { 'op' => 'remove', 'path' => '/1' }
+    ]
+    assert_raises(Hana::Patch::OutOfBoundsException) do
+      patch.apply([0])
+    end
+  end
+
+  def test_remove_missing_object_key_in_array
+    patch = Hana::Patch.new [
+      { 'op' => 'remove', 'path' => '/1/baz' }
+    ]
+    assert_raises(Hana::Patch::IndexError) do
+      patch.apply([
+        { 'foo' => 'bar' },
+        { 'foo' => 'bar' }
+      ])
+    end
+  end
+
+  def test_replace_missing_key
+    patch = Hana::Patch.new [
+      { 'op' => 'replace', 'path' => '/missing_key/field', 'value' => 'asdf' }
+    ]
+    assert_raises(Hana::Patch::MissingTargetException) do
+      patch.apply('foo' => 'bar')
+    end
+  end
 end


### PR DESCRIPTION
It was previously raising an `undefined method '[]=' for nil:NilClass` exception.

I also added some more test cases to check that `OutOfBoundsException` and `IndexError` are raised.