### PR TITLE
Fix unhandled exception removing deep missing path

### DIFF
--- a/lib/hana.rb
+++ b/lib/hana.rb
@@ -233,7 +233,7 @@ module Hana
         raise Patch::OutOfBoundsException if key >= obj.length
         obj.delete_at key
       else
-        raise Patch::IndexError unless obj.key? key
+        raise Patch::IndexError unless obj&.key? key
         obj.delete key
       end
     end

--- a/test/test_hana.rb
+++ b/test/test_hana.rb
@@ -79,7 +79,7 @@ class TestHana < Hana::TestCase
     end
   end
 
-  def test_remove_deep_missing_object_key
+  def test_remove_deep_missing_path
     patch = Hana::Patch.new [
       { 'op' => 'remove', 'path' => '/missing_key1/missing_key2' }
     ]

--- a/test/test_hana.rb
+++ b/test/test_hana.rb
@@ -79,6 +79,15 @@ class TestHana < Hana::TestCase
     end
   end
 
+  def test_remove_deep_missing_object_key
+    patch = Hana::Patch.new [
+      { 'op' => 'remove', 'path' => '/missing_key1/missing_key2' }
+    ]
+    assert_raises(Hana::Patch::IndexError) do
+      patch.apply('foo' => 'bar')
+    end
+  end
+
   def test_remove_missing_array_index
     patch = Hana::Patch.new [
       { 'op' => 'remove', 'path' => '/1' }


### PR DESCRIPTION
Hi @tenderlove,

Thanks for this library (and all your other great work 😃 ).

I came across an unhandled exception trying to remove a value from a deeply missing path. For example trying to remove `/missing_key1/missing_key2` from `{}`.

Hope this PR tested in the correct manner - let me know if you'd like any further changes.

Thanks,
Oli