### PR TITLE
Extend error reporting

### DIFF
--- a/lib/hana.rb
+++ b/lib/hana.rb
@@ -114,7 +114,7 @@ module Hana
       dest = Pointer.eval list, doc
       obj  = ins.fetch VALUE
 
-      raise(MissingTargetException, "unable to find path '#{ins['path']}'") unless dest
+      raise(MissingTargetException, "target location '#{ins['path']}' does not exist") unless dest
 
       if key
         add_op dest, key, obj
@@ -137,7 +137,7 @@ module Hana
       src      = Pointer.eval from, doc
       dest     = Pointer.eval to, doc
 
-      raise(MissingTargetException, "unable to find path '#{ins['path']}'") unless dest
+      raise(MissingTargetException, "target location '#{ins['path']}' does not exist") unless dest
 
       obj = rm_op src, from_key
       add_op dest, key, obj
@@ -160,11 +160,11 @@ module Hana
         begin
           obj = src.fetch from_key
         rescue KeyError, NoMethodError
-          raise Hana::Patch::MissingTargetException, "key '#{from_key} not found"
+          raise Hana::Patch::MissingTargetException, "'from' location '#{ins.fetch FROM}' does not exist"
         end
       end
 
-      raise(MissingTargetException, "unable to find path '#{ins['path']}'") unless dest
+      raise(MissingTargetException, "target location '#{ins['path']}' does not exist") unless dest
 
       add_op dest, key, obj
       doc

--- a/lib/hana.rb
+++ b/lib/hana.rb
@@ -227,11 +227,8 @@ module Hana
       if Array === dest
         dest.insert check_index(dest, key), obj
       else
-        begin
-          dest[key] = obj
-        rescue ::IndexError, ::NoMethodError
-          raise Patch::InvalidObjectOperationException, "cannot add key '#{key}' to non-object"
-        end
+        raise Patch::InvalidObjectOperationException, "cannot add key '#{key}' to non-object" unless Hash === dest
+        dest[key] = obj
       end
     end
 
@@ -245,7 +242,7 @@ module Hana
         begin
           raise Patch::MissingTargetException, "key '#{key}' not found" unless obj&.key? key
           obj.delete key
-        rescue ::IndexError, ::NoMethodError
+        rescue ::NoMethodError
           raise Patch::InvalidObjectOperationException, "cannot remove key '#{key}' from non-object"
         end
       end

--- a/lib/hana.rb
+++ b/lib/hana.rb
@@ -73,6 +73,9 @@ module Hana
     class ObjectOperationOnArrayException < Exception
     end
 
+    class InvalidObjectOperationException < Exception
+    end
+
     class IndexError < Exception
     end
 
@@ -104,22 +107,14 @@ module Hana
     OP    = 'op' # :nodoc:
 
     def add ins, doc
-      unless ins.key?('path')
-        raise Hana::Patch::InvalidPath, "missing 'path' parameter"
-      end
 
-      path = ins['path']
-
-      unless path
-        raise Hana::Patch::InvalidPath, "null is not valid value for 'path'"
-      end
-
+      path = get_path ins
       list = Pointer.parse path
       key  = list.pop
       dest = Pointer.eval list, doc
       obj  = ins.fetch VALUE
 
-      raise(MissingTargetException, ins['path']) unless dest
+      raise(MissingTargetException, "unable to find path '#{ins['path']}'") unless dest
 
       if key
         add_op dest, key, obj
@@ -134,18 +129,15 @@ module Hana
     end
 
     def move ins, doc
+      path = get_path ins
       from     = Pointer.parse ins.fetch FROM
-      to       = Pointer.parse ins[PATH]
+      to       = Pointer.parse path
       from_key = from.pop
       key      = to.pop
       src      = Pointer.eval from, doc
       dest     = Pointer.eval to, doc
 
-      unless Array === src
-        unless src.key? from_key
-          raise Hana::Patch::MissingTargetException
-        end
-      end
+      raise(MissingTargetException, "unable to find path '#{ins['path']}'") unless dest
 
       obj = rm_op src, from_key
       add_op dest, key, obj
@@ -153,68 +145,81 @@ module Hana
     end
 
     def copy ins, doc
+      path = get_path ins
       from     = Pointer.parse ins.fetch FROM
-      to       = Pointer.parse ins[PATH]
+      to       = Pointer.parse path
       from_key = from.pop
       key      = to.pop
       src      = Pointer.eval from, doc
       dest     = Pointer.eval to, doc
 
       if Array === src
-        raise Patch::IndexError unless from_key =~ /\A\d+\Z/
+        raise Patch::ObjectOperationOnArrayException, "cannot apply non-numeric key '#{key}' to array" unless from_key =~ /\A\d+\Z/
         obj = src.fetch from_key.to_i
       else
         begin
           obj = src.fetch from_key
-        rescue KeyError => e
-          raise Hana::Patch::MissingTargetException, e.message
+        rescue KeyError, NoMethodError
+          raise Hana::Patch::MissingTargetException, "key '#{from_key} not found"
         end
       end
+
+      raise(MissingTargetException, "unable to find path '#{ins['path']}'") unless dest
 
       add_op dest, key, obj
       doc
     end
 
     def test ins, doc
-      expected = Pointer.new(ins[PATH]).eval doc
+      path = get_path ins
+      expected = Pointer.new(path).eval doc
 
       unless expected == ins.fetch(VALUE)
-        raise FailedTestException.new(ins[VALUE], ins[PATH])
+        raise FailedTestException.new(ins[PATH], ins[VALUE])
       end
       doc
     end
 
     def replace ins, doc
-      list = Pointer.parse ins[PATH]
+      path = get_path ins
+      list = Pointer.parse path
       key  = list.pop
       obj  = Pointer.eval list, doc
 
       return ins.fetch VALUE unless key
 
-      if Array === obj
-        raise Patch::IndexError unless key =~ /\A\d+\Z/
-        obj[key.to_i] = ins.fetch VALUE
-      else
-        raise Patch::MissingTargetException unless obj
-        obj[key] = ins.fetch VALUE
-      end
+      rm_op obj, key
+      add_op obj, key, ins.fetch(VALUE)
       doc
     end
 
     def remove ins, doc
-      list = Pointer.parse ins[PATH]
+      path = get_path ins
+      list = Pointer.parse path
       key  = list.pop
       obj  = Pointer.eval list, doc
       rm_op obj, key
       doc
     end
 
+    def get_path ins
+      unless ins.key?('path')
+        raise Hana::Patch::InvalidPath, "missing 'path' parameter"
+      end
+
+      unless ins['path']
+        raise Hana::Patch::InvalidPath, "null is not valid value for 'path'"
+      end
+
+      ins['path']
+    end
+
     def check_index obj, key
       return -1 if key == '-'
 
-      raise ObjectOperationOnArrayException unless key =~ /\A-?\d+\Z/
+      raise ObjectOperationOnArrayException, "cannot apply non-numeric key '#{key}' to array" unless key =~ /\A-?\d+\Z/
       idx = key.to_i
-      raise OutOfBoundsException if idx > obj.length || idx < 0
+      raise OutOfBoundsException, "key '#{key}' is out of bounds for array" if idx > obj.length || idx < 0
       idx
     end
 
@@ -222,19 +227,27 @@ module Hana
       if Array === dest
         dest.insert check_index(dest, key), obj
       else
-        dest[key] = obj
+        begin
+          dest[key] = obj
+        rescue ::IndexError, ::NoMethodError
+          raise Patch::InvalidObjectOperationException, "cannot add key '#{key}' to non-object"
+        end
       end
     end
 
     def rm_op obj, key
       if Array === obj
-        raise Patch::IndexError unless key =~ /\A\d+\Z/
+        raise Patch::ObjectOperationOnArrayException, "cannot apply non-numeric key '#{key}' to array" unless key =~ /\A\d+\Z/
         key = key.to_i
-        raise Patch::OutOfBoundsException if key >= obj.length
+        raise Patch::OutOfBoundsException, "key '#{key}' is out of bounds for array" if key >= obj.length
         obj.delete_at key
       else
-        raise Patch::IndexError unless obj&.key? key
-        obj.delete key
+        begin
+          raise Patch::MissingTargetException, "key '#{key}' not found" unless obj&.key? key
+          obj.delete key
+        rescue ::IndexError, ::NoMethodError
+          raise Patch::InvalidObjectOperationException, "cannot remove key '#{key}' from non-object"
+        end
       end
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -60,7 +60,7 @@ module Hana
       when /bad number$/ then
         [Hana::Patch::IndexError, Hana::Patch::ObjectOperationOnArrayException]
       when /removing a nonexistent (field|index)/ then
-        [Hana::Patch::IndexError, Hana::Patch::OutOfBoundsException]
+        [Hana::Patch::MissingTargetException, Hana::Patch::OutOfBoundsException]
       when /test op should reject the array value, it has leading zeros/ then
         [Hana::Patch::IndexError]
       when /missing '(from|value)' parameter/ then

--- a/test/test_hana.rb
+++ b/test/test_hana.rb
@@ -74,7 +74,7 @@ class TestHana < Hana::TestCase
     patch = Hana::Patch.new [
       { 'op' => 'remove', 'path' => '/missing_key' }
     ]
-    assert_raises(Hana::Patch::IndexError) do
+    assert_raises(Hana::Patch::MissingTargetException) do
       patch.apply('foo' => 'bar')
     end
   end
@@ -83,7 +83,7 @@ class TestHana < Hana::TestCase
     patch = Hana::Patch.new [
       { 'op' => 'remove', 'path' => '/missing_key1/missing_key2' }
     ]
-    assert_raises(Hana::Patch::IndexError) do
+    assert_raises(Hana::Patch::MissingTargetException) do
       patch.apply('foo' => 'bar')
     end
   end
@@ -101,7 +101,7 @@ class TestHana < Hana::TestCase
     patch = Hana::Patch.new [
       { 'op' => 'remove', 'path' => '/1/baz' }
     ]
-    assert_raises(Hana::Patch::IndexError) do
+    assert_raises(Hana::Patch::MissingTargetException) do
       patch.apply([
         { 'foo' => 'bar' },
         { 'foo' => 'bar' }


### PR DESCRIPTION
Hi, thanks for the gem! It made setting up JSON Patch easy for us.

We had a requirement to have some more detail in the error messages when things went wrong, so this PR was made to accomplish that goal, but the scope did end up creeping a bit. This PR:

* Adds messages to existing errors that were being raised.
* Adds more error handling for some cases that weren't being caught. The two cases we found here were when `path` was not specified on operations other than `add`, and when the `path` tried to index into a string, boolean, or number (so if the `path` was `/birthDate/foo` and `/birthDate` was a string).
* Refactors the `replace` function to use `rm_op` and then `add_op`, instead of replacing the value directly. We did this because we noticed that if a `replace` operation was performed on target location which was on an object that existed, but didn't itself exist (so if `foo` was an object that didn't have a `bar` attribute, and the path was `/foo/bar`), `replace` would add the value, but by our reading of the [spec](https://tools.ietf.org/html/rfc6902#section-4.2) the `replace` should fail in this case.

We merged this as one PR on our fork, because we needed the error messaging soon, but if you'd prefer this PR be broken up into smaller ones that are more specific, let me know and we can definitely do that.