### PR TITLE
Update README.md: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ Then run the tests with:
 ```bash
 rake test
 ```
+
+[1]: https://datatracker.ietf.org/doc/rfc6902/
+[2]: http://tools.ietf.org/html/rfc6901
+


### PR DESCRIPTION
In f264e5cadc5e67fef7b19bc21eb453509c83103d the MIT license in the README file was updated, but [the two reference-style links for the referenced RFCs were accidentally dropped](https://github.com/tenderlove/hana/commit/f264e5cadc5e67fef7b19bc21eb453509c83103d#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-L81), so this PR moves them back, and fixes the broken `JSON Patch` and `JSON Pointer` links in the process.